### PR TITLE
修复Communicator的$_statF会为null的错误

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phptars/tars-client",
     "description": "tars的php-client能力",
-    "version":"0.3.0",
+    "version":"0.3.1",
     "authors": [
         {
             "name": "Chen Liang",

--- a/src/Communicator.php
+++ b/src/Communicator.php
@@ -66,7 +66,7 @@ class Communicator
             $this->_queryF = new QueryFWrapper($this->_locator, $this->_routeSocketMode, $this->_refreshEndpointInterval);
             $this->_routeInfo = $this->_queryF->findObjectById($this->_servantName);
             // 初始化上报组件,只在指定了主控的前提下
-            if(class_exists("\Tars\App")) {
+            if(class_exists("\Tars\App") && \Tars\App::getStatF()) {
                 $this->_statF = \Tars\App::getStatF();
             }
             else {


### PR DESCRIPTION
在同时依赖phptars/tars-client 和 phptars/tars-server 时，使用非tars运行项目时（比如队列等情况），使用tars客户端会出现调用失败的情况，Communicator的$_statF为null，未设置成功导致的。